### PR TITLE
Add gameStore happy path tests for Hero of Soviet Union and round progression

### DIFF
--- a/src/tests/store/gameStore.test.ts
+++ b/src/tests/store/gameStore.test.ts
@@ -1,0 +1,253 @@
+// Copyright © 2025 William Lay
+// Licensed under the PolyForm Noncommercial License 1.0.0
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useGameStore } from '../../store/gameStore'
+
+describe('gameStore - Hero of Soviet Union', () => {
+  beforeEach(() => {
+    // Reset store to clean state
+    useGameStore.setState({
+      gamePhase: 'welcome',
+      players: [],
+      heroesOfSovietUnion: [],
+      gameLog: [],
+      roundNumber: 1
+    })
+  })
+
+  describe('grantHeroOfSovietUnion', () => {
+    it('should grant Hero of Soviet Union status to a player', () => {
+      const { initializePlayers, grantHeroOfSovietUnion, isHeroOfSovietUnion } = useGameStore.getState()
+
+      initializePlayers([
+        { name: 'Player 1', piece: 'sickle', isStalin: false }
+      ])
+
+      const player = useGameStore.getState().players[0]
+      grantHeroOfSovietUnion(player.id)
+
+      expect(isHeroOfSovietUnion(player.id)).toBe(true)
+
+      const state = useGameStore.getState()
+      expect(state.heroesOfSovietUnion).toHaveLength(1)
+      expect(state.heroesOfSovietUnion[0].playerId).toBe(player.id)
+      expect(state.heroesOfSovietUnion[0].grantedAtRound).toBe(state.roundNumber)
+      expect(state.heroesOfSovietUnion[0].expiresAtRound).toBe(state.roundNumber + 3)
+    })
+
+    it('should not grant duplicate Hero status if player is already a Hero', () => {
+      const { initializePlayers, grantHeroOfSovietUnion } = useGameStore.getState()
+
+      initializePlayers([
+        { name: 'Player 1', piece: 'sickle', isStalin: false }
+      ])
+
+      const player = useGameStore.getState().players[0]
+
+      // Grant hero status first time
+      grantHeroOfSovietUnion(player.id)
+      const heroesAfterFirst = useGameStore.getState().heroesOfSovietUnion
+      expect(heroesAfterFirst).toHaveLength(1)
+
+      // Try to grant again - should be rejected
+      grantHeroOfSovietUnion(player.id)
+      const heroesAfterSecond = useGameStore.getState().heroesOfSovietUnion
+      expect(heroesAfterSecond).toHaveLength(1) // Still only 1 hero entry
+
+      // Verify log message was added
+      const gameLog = useGameStore.getState().gameLog
+      const duplicateLog = gameLog.find(log =>
+        log.message.includes('is already a Hero of the Soviet Union')
+      )
+      expect(duplicateLog).toBeDefined()
+      expect(duplicateLog?.type).toBe('system')
+    })
+
+    it('should not grant Hero status to non-existent player', () => {
+      const { initializePlayers, grantHeroOfSovietUnion } = useGameStore.getState()
+
+      initializePlayers([
+        { name: 'Player 1', piece: 'sickle', isStalin: false }
+      ])
+
+      const initialHeroes = useGameStore.getState().heroesOfSovietUnion
+
+      // Try to grant to non-existent player ID
+      grantHeroOfSovietUnion('non-existent-id')
+
+      const afterHeroes = useGameStore.getState().heroesOfSovietUnion
+      expect(afterHeroes).toEqual(initialHeroes) // No change
+    })
+  })
+
+  describe('isHeroOfSovietUnion', () => {
+    it('should return true for active hero', () => {
+      const { initializePlayers, grantHeroOfSovietUnion, isHeroOfSovietUnion } = useGameStore.getState()
+
+      initializePlayers([
+        { name: 'Player 1', piece: 'sickle', isStalin: false }
+      ])
+
+      const player = useGameStore.getState().players[0]
+      grantHeroOfSovietUnion(player.id)
+
+      expect(isHeroOfSovietUnion(player.id)).toBe(true)
+    })
+
+    it('should return false for non-hero player', () => {
+      const { initializePlayers, isHeroOfSovietUnion } = useGameStore.getState()
+
+      initializePlayers([
+        { name: 'Player 1', piece: 'sickle', isStalin: false }
+      ])
+
+      const player = useGameStore.getState().players[0]
+      expect(isHeroOfSovietUnion(player.id)).toBe(false)
+    })
+
+    it('should return false for expired hero', () => {
+      const { initializePlayers, grantHeroOfSovietUnion, isHeroOfSovietUnion } = useGameStore.getState()
+
+      initializePlayers([
+        { name: 'Player 1', piece: 'sickle', isStalin: false }
+      ])
+
+      const player = useGameStore.getState().players[0]
+      grantHeroOfSovietUnion(player.id)
+
+      // Verify hero is active
+      expect(isHeroOfSovietUnion(player.id)).toBe(true)
+
+      // Manually advance round number past expiration
+      const state = useGameStore.getState()
+      useGameStore.setState({ roundNumber: state.roundNumber + 3 })
+
+      // Hero should now be expired
+      expect(isHeroOfSovietUnion(player.id)).toBe(false)
+    })
+
+    it('should handle hero expiration correctly at exactly 3 rounds', () => {
+      const { initializePlayers, grantHeroOfSovietUnion, isHeroOfSovietUnion } = useGameStore.getState()
+
+      initializePlayers([
+        { name: 'Player 1', piece: 'sickle', isStalin: false }
+      ])
+
+      const player = useGameStore.getState().players[0]
+      const initialRound = useGameStore.getState().roundNumber
+
+      grantHeroOfSovietUnion(player.id)
+
+      // At round +1: still hero
+      useGameStore.setState({ roundNumber: initialRound + 1 })
+      expect(isHeroOfSovietUnion(player.id)).toBe(true)
+
+      // At round +2: still hero
+      useGameStore.setState({ roundNumber: initialRound + 2 })
+      expect(isHeroOfSovietUnion(player.id)).toBe(true)
+
+      // At round +3: expired (expiresAtRound > currentRound fails)
+      useGameStore.setState({ roundNumber: initialRound + 3 })
+      expect(isHeroOfSovietUnion(player.id)).toBe(false)
+    })
+  })
+})
+
+describe('gameStore - Round Progression', () => {
+  beforeEach(() => {
+    // Reset store to clean state
+    useGameStore.setState({
+      gamePhase: 'welcome',
+      players: [],
+      heroesOfSovietUnion: [],
+      gameLog: [],
+      roundNumber: 1,
+      denouncementsThisRound: []
+    })
+  })
+
+  describe('incrementRound', () => {
+    it('should increment round number by 1', () => {
+      const { initializePlayers, incrementRound } = useGameStore.getState()
+
+      initializePlayers([
+        { name: 'Player 1', piece: 'sickle', isStalin: false }
+      ])
+
+      const initialRound = useGameStore.getState().roundNumber
+      incrementRound()
+      const newRound = useGameStore.getState().roundNumber
+
+      expect(newRound).toBe(initialRound + 1)
+    })
+
+    it('should clear denouncements from previous round', () => {
+      const { initializePlayers, incrementRound } = useGameStore.getState()
+
+      initializePlayers([
+        { name: 'Player 1', piece: 'sickle', isStalin: false },
+        { name: 'Player 2', piece: 'hammer', isStalin: false }
+      ])
+
+      const [player1, player2] = useGameStore.getState().players
+
+      // Add some denouncements
+      useGameStore.setState({
+        denouncementsThisRound: [
+          { denouncer: player1.id, denounced: player2.id }
+        ]
+      })
+
+      expect(useGameStore.getState().denouncementsThisRound).toHaveLength(1)
+
+      // Increment round should clear denouncements
+      incrementRound()
+
+      expect(useGameStore.getState().denouncementsThisRound).toHaveLength(0)
+    })
+
+    it('should reset KGB test preview counter for all players', () => {
+      const { initializePlayers, updatePlayer, incrementRound } = useGameStore.getState()
+
+      initializePlayers([
+        { name: 'Player 1', piece: 'sickle', isStalin: false },
+        { name: 'Player 2', piece: 'hammer', isStalin: false }
+      ])
+
+      const [player1, player2] = useGameStore.getState().players
+
+      // Set preview counters
+      updatePlayer(player1.id, { kgbTestPreviewsUsedThisRound: 2 })
+      updatePlayer(player2.id, { kgbTestPreviewsUsedThisRound: 1 })
+
+      // Verify they're set
+      expect(useGameStore.getState().players[0].kgbTestPreviewsUsedThisRound).toBe(2)
+      expect(useGameStore.getState().players[1].kgbTestPreviewsUsedThisRound).toBe(1)
+
+      // Increment round
+      incrementRound()
+
+      // Verify counters are reset
+      expect(useGameStore.getState().players[0].kgbTestPreviewsUsedThisRound).toBe(0)
+      expect(useGameStore.getState().players[1].kgbTestPreviewsUsedThisRound).toBe(0)
+    })
+
+    it('should not reset KGB test preview counter if already 0', () => {
+      const { initializePlayers, incrementRound } = useGameStore.getState()
+
+      initializePlayers([
+        { name: 'Player 1', piece: 'sickle', isStalin: false }
+      ])
+
+      // Player already has 0 previews used
+      expect(useGameStore.getState().players[0].kgbTestPreviewsUsedThisRound).toBe(0)
+
+      // Increment round (line 2810 should not be hit)
+      incrementRound()
+
+      // Still 0
+      expect(useGameStore.getState().players[0].kgbTestPreviewsUsedThisRound).toBe(0)
+    })
+  })
+})


### PR DESCRIPTION
Tests cover:
- Hero of Soviet Union: granting, duplicate prevention, expiration, status checks
- incrementRound: round increment, denouncement clearing, KGB preview reset

All 11 tests passing. Coverage improvements for gameStore.ts lines 2769-2773, 2810.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>