### PR TITLE
Enable-dependabot-groups

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# CODEOWNERS file
+# These owners will be automatically requested for review when someone opens a PR
+
+# Default owner for everything in the repo
+* @laywill
+
+# Dependency files (for dependabot PRs)
+package.json @laywill
+package-lock.json @laywill
+
+# GitHub Actions workflows
+.github/workflows/* @laywill
+
+# Devcontainer configuration
+.devcontainer/* @laywill

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
       - "github_actions"
       - "chore"
       - "dependencies"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
   # Maintain dependencies for NPM Modules
   - package-ecosystem: "npm"
     # Look for `package.json` and `lock` files in the `root` directory
@@ -23,14 +27,32 @@ updates:
       - "dependencies"
       - "chore"
     groups:
-      development-dependencies:
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"
+          - "typescript-eslint"
+      vite-ecosystem:
+        patterns:
+          - "vite"
+          - "@vitejs/*"
+      vitest-ecosystem:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+      eslint-plugins:
+        patterns:
+          - "eslint-plugin-*"
+      testing:
+        patterns:
+          - "@testing-library/*"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react*"
+      other-dependencies:
         patterns:
           - "*"
-        dependency-type: "development"
-      production-dependencies:
-        patterns:
-          - "*"
-        dependency-type: "production"
   # Maintain dependencies for Devcontainer dependencies
   - package-ecosystem: "devcontainers"
     directory: "/"
@@ -38,3 +60,7 @@ updates:
       interval: "weekly"
     labels:
       - "chore"
+    groups:
+      devcontainer:
+        patterns:
+          - "*"


### PR DESCRIPTION
Replace broad dev/prod dependency groups with ecosystem-specific groups
(typescript-eslint, vite, vitest, eslint-plugins, testing, react) to
better handle interdependencies and reduce merge conflicts. Add grouping
for github-actions and devcontainer ecosystems. Replace deprecated
reviewers field with CODEOWNERS file for automatic review assignment.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>