### PR TITLE
Fix duplicate voucher IDs causing test failures

### DIFF
--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -1296,7 +1296,7 @@ export const useGameStore = create<GameStore>()(
       createVoucher: (prisonerId, voucherId) => {
         const state = get()
         const voucher: VoucherAgreement = {
-          id: `voucher-${String(Date.now())}`,
+          id: `voucher-${String(Date.now())}-${prisonerId}`,
           prisonerId,
           voucherId,
           expiresAtRound: (state.roundNumber) + 3,


### PR DESCRIPTION
Voucher IDs were generated using only Date.now(), which could create
identical IDs when multiple vouchers were created in the same millisecond
during tests. This caused the expireVouchers function to incorrectly expire
all vouchers with the same ID. Fixed by including prisonerId in the ID
generation to ensure uniqueness.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>