### PR TITLE
Fix Gulag escape incorrectly moving players on failed rolls

### DIFF
--- a/src/store/slices/diceSlice.ts
+++ b/src/store/slices/diceSlice.ts
@@ -115,8 +115,14 @@ export const createDiceSlice: StateCreator<
       turnPhase: 'moving'
     })
 
-    // Move the player by the dice total
+    // Move the player by the dice total (only if not in Gulag)
     const currentPlayer = players[currentPlayerIndex]
+
+    // Don't move players in Gulag - attemptGulagEscape handles their movement
+    if (currentPlayer.inGulag) {
+      return
+    }
+
     const diceTotal = die1 + die2
     get().movePlayer(currentPlayer.id, diceTotal)
   },


### PR DESCRIPTION
Players in Gulag were being moved by dice totals even when they failed to roll the required doubles for escape. The finishRolling() method in diceSlice now checks if a player is in Gulag and skips movement, as attemptGulagEscape handles movement only on successful escapes.

Added regression tests to verify players don't move when:
- Rolling non-doubles in Gulag (e.g., 5+6)
- Rolling insufficient doubles (e.g., double 4s when needing 5s or 6s)

Fixes #77

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>